### PR TITLE
User Callbacks in PulsarSource and PulsarSink

### DIFF
--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/PulsarSink.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/PulsarSink.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.connector.pulsar.sink;
 
-import static org.apache.flink.util.Preconditions.checkNotNull;
-
-import javax.annotation.Nullable;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.sink2.Committer;
@@ -42,7 +39,12 @@ import org.apache.flink.connector.pulsar.sink.writer.router.TopicRoutingMode;
 import org.apache.flink.connector.pulsar.sink.writer.serializer.PulsarSerializationSchema;
 import org.apache.flink.connector.pulsar.sink.writer.topic.MetadataListener;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
+
 import org.apache.pulsar.client.api.PulsarClientException;
+
+import javax.annotation.Nullable;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * The Sink implementation of Pulsar. Please use a {@link PulsarSinkBuilder} to construct a {@link

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/PulsarSinkBuilder.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/PulsarSinkBuilder.java
@@ -26,7 +26,10 @@ import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.connector.pulsar.common.config.PulsarConfigBuilder;
 import org.apache.flink.connector.pulsar.common.config.PulsarOptions;
 import org.apache.flink.connector.pulsar.common.crypto.PulsarCrypto;
+import org.apache.flink.connector.pulsar.sink.callback.SinkUserCallback;
+import org.apache.flink.connector.pulsar.sink.callback.SinkUserCallbackFactory;
 import org.apache.flink.connector.pulsar.sink.config.SinkConfiguration;
+import org.apache.flink.connector.pulsar.sink.writer.PulsarWriter;
 import org.apache.flink.connector.pulsar.sink.writer.delayer.MessageDelayer;
 import org.apache.flink.connector.pulsar.sink.writer.router.TopicRouter;
 import org.apache.flink.connector.pulsar.sink.writer.router.TopicRoutingMode;
@@ -115,6 +118,7 @@ public class PulsarSinkBuilder<IN> {
     private TopicRouter<IN> topicRouter;
     private MessageDelayer<IN> messageDelayer;
     private PulsarCrypto pulsarCrypto;
+    private SinkUserCallbackFactory<IN> userCallbackFactory;
 
     // private builder constructor.
     PulsarSinkBuilder() {
@@ -389,6 +393,19 @@ public class PulsarSinkBuilder<IN> {
     }
 
     /**
+     * Set a factory for the {@link SinkUserCallback}. A callback is instantiated in each {@link
+     * PulsarWriter} and disposed of when the app shuts down.
+     *
+     * @param userCallbackFactory the factory.
+     * @return this PuslarSourceBuilder
+     */
+    public PulsarSinkBuilder<IN> setUserCallbackFactory(
+            SinkUserCallbackFactory<IN> userCallbackFactory) {
+        this.userCallbackFactory = userCallbackFactory;
+        return this;
+    }
+
+    /**
      * Build the {@link PulsarSink}.
      *
      * @return a PulsarSink with the settings made for this builder.
@@ -484,7 +501,8 @@ public class PulsarSinkBuilder<IN> {
                 topicRoutingMode,
                 topicRouter,
                 messageDelayer,
-                pulsarCrypto);
+                pulsarCrypto,
+                userCallbackFactory);
     }
 
     // ------------- private helpers  --------------

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
@@ -32,5 +32,5 @@ public interface SinkUserCallback<IN> extends AutoCloseable {
      * @param topic the topic or partition that the message was sent to.
      * @param ex the exception.
      */
-    void onSendFailed(IN element, PulsarMessage<?> message, String topic, @Nullable Throwable ex);
+    void onSendFailed(IN element, PulsarMessage<?> message, String topic, Throwable ex);
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
@@ -1,0 +1,26 @@
+package org.apache.flink.connector.pulsar.sink.callback;
+
+import javax.annotation.Nullable;
+import org.apache.flink.connector.pulsar.sink.writer.message.PulsarMessage;
+import org.apache.pulsar.client.api.MessageId;
+
+public interface SinkUserCallback<T> extends AutoCloseable {
+    /**
+     * This method is called before the message is sent to the topic.
+     * The user can modify the message. By default, the same message will be returned.
+     * @param message the message received from the previous operator.
+     * @return the message to send to the pulsar topic.
+     */
+    default PulsarMessage<T> beforeSend(PulsarMessage<T> message) {
+        return message;
+    }
+
+
+    /**
+     * This method is called after producer has tried to write the message to the topic.
+     * @param message the message that was sent to the topic
+     * @param messageId the topic MessageId, if the send was successfull
+     * @param ex the exception if the send failed.
+     */
+    void afterSend(PulsarMessage<T> message, @Nullable MessageId messageId, @Nullable Throwable ex);
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
@@ -21,7 +21,7 @@ public interface SinkUserCallback<IN> extends AutoCloseable {
      * This method is called after producer has tried to write the message to the topic.
      * @param element the element received from the previous operator.
      * @param message the message that was sent to the topic.
-     * @param messageId the topic MessageId, if the send was successfull.
+     * @param messageId the topic MessageId, if the send operation was successful.
      */
     void onSendSucceeded(IN element, PulsarMessage<?> message, String topic, MessageId messageId);
 

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
@@ -35,11 +35,8 @@ public interface SinkUserCallback<IN> extends AutoCloseable {
      * @param element the element received from the previous operator.
      * @param message the message wrapper with the element already serialized.
      * @param topic the pulsar topic or partition that the message will be routed to.
-     * @return the message to send to the pulsar topic, potentially a new message.
      */
-    default PulsarMessage<?> beforeSend(IN element, PulsarMessage<?> message, String topic) {
-        return message;
-    }
+    void beforeSend(IN element, PulsarMessage<?> message, String topic);
 
     /**
      * This method is called after producer has tried to write the message to the topic.

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
@@ -4,14 +4,14 @@ import javax.annotation.Nullable;
 import org.apache.flink.connector.pulsar.sink.writer.message.PulsarMessage;
 import org.apache.pulsar.client.api.MessageId;
 
-public interface SinkUserCallback<T> extends AutoCloseable {
+public interface SinkUserCallback<IN, OUT> extends AutoCloseable {
     /**
      * This method is called before the message is sent to the topic.
      * The user can modify the message. By default, the same message will be returned.
      * @param message the message received from the previous operator.
      * @return the message to send to the pulsar topic.
      */
-    default PulsarMessage<T> beforeSend(PulsarMessage<T> message) {
+    default PulsarMessage<OUT> beforeSend(IN element, PulsarMessage<OUT> message) {
         return message;
     }
 
@@ -22,5 +22,5 @@ public interface SinkUserCallback<T> extends AutoCloseable {
      * @param messageId the topic MessageId, if the send was successfull
      * @param ex the exception if the send failed.
      */
-    void afterSend(PulsarMessage<T> message, @Nullable MessageId messageId, @Nullable Throwable ex);
+    void afterSend(IN element, PulsarMessage<OUT> message, @Nullable MessageId messageId, @Nullable Throwable ex);
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
@@ -4,14 +4,15 @@ import javax.annotation.Nullable;
 import org.apache.flink.connector.pulsar.sink.writer.message.PulsarMessage;
 import org.apache.pulsar.client.api.MessageId;
 
-public interface SinkUserCallback<IN, OUT> extends AutoCloseable {
+public interface SinkUserCallback<IN> extends AutoCloseable {
     /**
      * This method is called before the message is sent to the topic.
      * The user can modify the message. By default, the same message will be returned.
-     * @param message the message received from the previous operator.
+     * @param element the element received from the previous operator.
+     * @param message the message wrapper with the element already serialized.
      * @return the message to send to the pulsar topic.
      */
-    default PulsarMessage<OUT> beforeSend(IN element, PulsarMessage<OUT> message) {
+    default PulsarMessage<?> beforeSend(IN element, PulsarMessage<?> message) {
         return message;
     }
 
@@ -22,5 +23,5 @@ public interface SinkUserCallback<IN, OUT> extends AutoCloseable {
      * @param messageId the topic MessageId, if the send was successfull
      * @param ex the exception if the send failed.
      */
-    void afterSend(IN element, PulsarMessage<OUT> message, @Nullable MessageId messageId, @Nullable Throwable ex);
+    void afterSend(IN element, PulsarMessage<?> message, @Nullable MessageId messageId, @Nullable Throwable ex);
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.pulsar.sink.callback;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.connector.pulsar.sink.writer.message.PulsarMessage;
 
 import org.apache.pulsar.client.api.MessageId;
@@ -27,6 +28,7 @@ import org.apache.pulsar.client.api.MessageId;
  *
  * @param <IN> The input type of the sink
  */
+@PublicEvolving
 public interface SinkUserCallback<IN> extends AutoCloseable {
     /**
      * This method is called before the message is sent to the topic. The user can modify the

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.connector.pulsar.sink.callback;
 
 import org.apache.flink.connector.pulsar.sink.writer.message.PulsarMessage;

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
@@ -1,13 +1,19 @@
 package org.apache.flink.connector.pulsar.sink.callback;
 
-import javax.annotation.Nullable;
 import org.apache.flink.connector.pulsar.sink.writer.message.PulsarMessage;
+
 import org.apache.pulsar.client.api.MessageId;
 
+/**
+ * An optional callback interface that users can plug into PulsarSink.
+ *
+ * @param <IN> The input type of the sink
+ */
 public interface SinkUserCallback<IN> extends AutoCloseable {
     /**
-     * This method is called before the message is sent to the topic.
-     * The user can modify the message. By default, the same message will be returned.
+     * This method is called before the message is sent to the topic. The user can modify the
+     * message. By default, the same message will be returned.
+     *
      * @param element the element received from the previous operator.
      * @param message the message wrapper with the element already serialized.
      * @param topic the pulsar topic or partition that the message will be routed to.
@@ -19,6 +25,7 @@ public interface SinkUserCallback<IN> extends AutoCloseable {
 
     /**
      * This method is called after producer has tried to write the message to the topic.
+     *
      * @param element the element received from the previous operator.
      * @param message the message that was sent to the topic.
      * @param messageId the topic MessageId, if the send operation was successful.
@@ -27,6 +34,7 @@ public interface SinkUserCallback<IN> extends AutoCloseable {
 
     /**
      * This method is called after producer has tried to write the message to the topic.
+     *
      * @param element the element received from the previous operator.
      * @param message the message that was sent to the topic.
      * @param topic the topic or partition that the message was sent to.

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallback.java
@@ -10,18 +10,27 @@ public interface SinkUserCallback<IN> extends AutoCloseable {
      * The user can modify the message. By default, the same message will be returned.
      * @param element the element received from the previous operator.
      * @param message the message wrapper with the element already serialized.
-     * @return the message to send to the pulsar topic.
+     * @param topic the pulsar topic or partition that the message will be routed to.
+     * @return the message to send to the pulsar topic, potentially a new message.
      */
-    default PulsarMessage<?> beforeSend(IN element, PulsarMessage<?> message) {
+    default PulsarMessage<?> beforeSend(IN element, PulsarMessage<?> message, String topic) {
         return message;
     }
 
+    /**
+     * This method is called after producer has tried to write the message to the topic.
+     * @param element the element received from the previous operator.
+     * @param message the message that was sent to the topic.
+     * @param messageId the topic MessageId, if the send was successfull.
+     */
+    void onSendSucceeded(IN element, PulsarMessage<?> message, String topic, MessageId messageId);
 
     /**
      * This method is called after producer has tried to write the message to the topic.
-     * @param message the message that was sent to the topic
-     * @param messageId the topic MessageId, if the send was successfull
-     * @param ex the exception if the send failed.
+     * @param element the element received from the previous operator.
+     * @param message the message that was sent to the topic.
+     * @param topic the topic or partition that the message was sent to.
+     * @param ex the exception.
      */
-    void afterSend(IN element, PulsarMessage<?> message, @Nullable MessageId messageId, @Nullable Throwable ex);
+    void onSendFailed(IN element, PulsarMessage<?> message, String topic, @Nullable Throwable ex);
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallbackFactory.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallbackFactory.java
@@ -1,7 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.connector.pulsar.sink.callback;
 
 import java.io.Serializable;
 
+ /** A serializable factory for SinkUserCallback.
+  * @param <IN> the input type of the Sink */
 public interface SinkUserCallbackFactory<IN> extends Serializable {
     SinkUserCallback<IN> create();
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallbackFactory.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallbackFactory.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.connector.pulsar.sink.callback;
 
+import org.apache.flink.annotation.PublicEvolving;
+
 import java.io.Serializable;
 
 /**
@@ -25,6 +27,7 @@ import java.io.Serializable;
  *
  * @param <IN> the input type of the Sink
  */
+@PublicEvolving
 public interface SinkUserCallbackFactory<IN> extends Serializable {
     SinkUserCallback<IN> create();
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallbackFactory.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallbackFactory.java
@@ -2,6 +2,6 @@ package org.apache.flink.connector.pulsar.sink.callback;
 
 import java.io.Serializable;
 
-public interface SinkUserCallbackFactory<T> extends Serializable {
-    SinkUserCallback<T> create();
+public interface SinkUserCallbackFactory extends Serializable {
+    SinkUserCallback create();
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallbackFactory.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallbackFactory.java
@@ -1,0 +1,7 @@
+package org.apache.flink.connector.pulsar.sink.callback;
+
+import java.io.Serializable;
+
+public interface SinkUserCallbackFactory<T> extends Serializable {
+    SinkUserCallback<T> create();
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallbackFactory.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallbackFactory.java
@@ -20,8 +20,11 @@ package org.apache.flink.connector.pulsar.sink.callback;
 
 import java.io.Serializable;
 
- /** A serializable factory for SinkUserCallback.
-  * @param <IN> the input type of the Sink */
+/**
+ * A serializable factory for SinkUserCallback.
+ *
+ * @param <IN> the input type of the Sink
+ */
 public interface SinkUserCallbackFactory<IN> extends Serializable {
     SinkUserCallback<IN> create();
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallbackFactory.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/callback/SinkUserCallbackFactory.java
@@ -2,6 +2,6 @@ package org.apache.flink.connector.pulsar.sink.callback;
 
 import java.io.Serializable;
 
-public interface SinkUserCallbackFactory extends Serializable {
-    SinkUserCallback create();
+public interface SinkUserCallbackFactory<IN> extends Serializable {
+    SinkUserCallback<IN> create();
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
@@ -18,17 +18,6 @@
 
 package org.apache.flink.connector.pulsar.sink.writer;
 
-import static java.util.Collections.emptyList;
-import static org.apache.flink.util.IOUtils.closeAll;
-import static org.apache.flink.util.Preconditions.checkNotNull;
-
-import java.io.IOException;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicLong;
-import javax.annotation.Nullable;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.api.common.operators.ProcessingTimeService;
@@ -50,14 +39,29 @@ import org.apache.flink.connector.pulsar.sink.writer.topic.MetadataListener;
 import org.apache.flink.connector.pulsar.sink.writer.topic.ProducerRegister;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
-import org.apache.flink.shaded.guava30.com.google.common.base.Strings;
 import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.flink.shaded.guava30.com.google.common.base.Strings;
+
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.util.Collections.emptyList;
+import static org.apache.flink.util.IOUtils.closeAll;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * This class is responsible to write records in a Pulsar topic and to handle the different delivery
@@ -96,14 +100,14 @@ public class PulsarWriter<IN> implements PrecommittingSinkWriter<IN, PulsarCommi
      * @param initContext Context to provide information about the runtime environment.
      */
     public PulsarWriter(
-        SinkConfiguration sinkConfiguration,
-        PulsarSerializationSchema<IN> serializationSchema,
-        MetadataListener metadataListener,
-        TopicRouter<IN> topicRouter,
-        MessageDelayer<IN> messageDelayer,
-        PulsarCrypto pulsarCrypto,
-        InitContext initContext,
-        @Nullable SinkUserCallback<IN> userCallback)
+            SinkConfiguration sinkConfiguration,
+            PulsarSerializationSchema<IN> serializationSchema,
+            MetadataListener metadataListener,
+            TopicRouter<IN> topicRouter,
+            MessageDelayer<IN> messageDelayer,
+            PulsarCrypto pulsarCrypto,
+            InitContext initContext,
+            @Nullable SinkUserCallback<IN> userCallback)
             throws PulsarClientException {
         checkNotNull(sinkConfiguration);
         this.serializationSchema = checkNotNull(serializationSchema);
@@ -172,9 +176,10 @@ public class PulsarWriter<IN> implements PrecommittingSinkWriter<IN, PulsarCommi
         if (deliveryGuarantee == DeliveryGuarantee.NONE) {
             // We would just ignore the sending exception. This may cause data loss.
             sendFuture = builder.sendAsync();
-            sendFuture.whenComplete((id, ex) -> {
-                callUserCallbackAfterSend(element, userMessage, topic, id, ex);
-            });
+            sendFuture.whenComplete(
+                    (id, ex) -> {
+                        callUserCallbackAfterSend(element, userMessage, topic, id, ex);
+                    });
         } else {
             // Increase the pending message count.
             pendingMessages.incrementAndGet();
@@ -195,7 +200,11 @@ public class PulsarWriter<IN> implements PrecommittingSinkWriter<IN, PulsarCommi
     }
 
     private void callUserCallbackAfterSend(
-        IN element, PulsarMessage<?> message, String topic, MessageId messageId, Throwable exception) {
+            IN element,
+            PulsarMessage<?> message,
+            String topic,
+            MessageId messageId,
+            Throwable exception) {
         if (userCallback == null) {
             return;
         }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
@@ -156,12 +156,7 @@ public class PulsarWriter<IN> implements PrecommittingSinkWriter<IN, PulsarCommi
         TopicPartition partition = topicRouter.route(element, key, partitions, sinkContext);
         String topic = partition.getFullTopicName();
 
-        // invoke user callback before send
-        if (userCallback != null) {
-            message = userCallback.beforeSend(element, message, topic);
-        }
-
-        // Create message builder for sending messages.
+        // Create message builder for sending messages
         final PulsarMessage<?> userMessage = message;
         TypedMessageBuilder<?> builder = createMessageBuilder(topic, context, userMessage);
 
@@ -169,6 +164,11 @@ public class PulsarWriter<IN> implements PrecommittingSinkWriter<IN, PulsarCommi
         long deliverAt = messageDelayer.deliverAt(element, sinkContext);
         if (deliverAt > 0) {
             builder.deliverAt(deliverAt);
+        }
+
+        // invoke user callback before send
+        if (userCallback != null) {
+            userCallback.beforeSend(element, message, topic);
         }
 
         // Perform message sending.

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
@@ -78,7 +78,7 @@ public class PulsarWriter<IN> implements PrecommittingSinkWriter<IN, PulsarCommi
     private final MailboxExecutor mailboxExecutor;
     private final AtomicLong pendingMessages;
 
-    private SinkUserCallback userCallback; //todo: make final
+    private SinkUserCallback<IN> userCallback; //todo: make final
 
     /**
      * Constructor creating a Pulsar writer.

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
@@ -272,6 +272,10 @@ public class PulsarWriter<IN> implements PrecommittingSinkWriter<IN, PulsarCommi
     @Override
     public void close() throws Exception {
         // Close all the resources and throw the exception at last.
-        closeAll(metadataListener, producerRegister);
+        if (userCallback == null) {
+            closeAll(metadataListener, producerRegister);
+        } else {
+            closeAll(metadataListener, producerRegister, userCallback);
+        }
     }
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
@@ -304,10 +304,6 @@ public class PulsarWriter<IN> implements PrecommittingSinkWriter<IN, PulsarCommi
     @Override
     public void close() throws Exception {
         // Close all the resources and throw the exception at last.
-        if (userCallback == null) {
-            closeAll(metadataListener, producerRegister);
-        } else {
-            closeAll(metadataListener, producerRegister, userCallback);
-        }
+        closeAll(metadataListener, producerRegister, userCallback);
     }
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
@@ -142,16 +142,16 @@ public class PulsarWriter<IN> implements PrecommittingSinkWriter<IN, PulsarCommi
     public void write(IN element, Context context) throws IOException, InterruptedException {
         PulsarMessage<?> message = serializationSchema.serialize(element, sinkContext);
 
-        // process via user callback before send
-        if (userCallback != null) {
-            message = userCallback.beforeSend(element, message);
-        }
-
         // Choose the right topic to send.
         String key = message.getKey();
         List<TopicPartition> partitions = metadataListener.availablePartitions();
         TopicPartition partition = topicRouter.route(element, key, partitions, sinkContext);
         String topic = partition.getFullTopicName();
+
+        // process via user callback before send
+        if (userCallback != null) {
+            message = userCallback.beforeSend(element, message, topic);
+        }
 
         // Create message builder for sending messages.
         TypedMessageBuilder<?> builder = createMessageBuilder(topic, context, message);

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSourceBuilder.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSourceBuilder.java
@@ -23,11 +23,14 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.pulsar.common.config.PulsarConfigBuilder;
 import org.apache.flink.connector.pulsar.common.config.PulsarOptions;
 import org.apache.flink.connector.pulsar.common.crypto.PulsarCrypto;
+import org.apache.flink.connector.pulsar.source.callback.SourceUserCallback;
+import org.apache.flink.connector.pulsar.source.callback.SourceUserCallbackFactory;
 import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
 import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
 import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
@@ -138,6 +141,8 @@ public final class PulsarSourceBuilder<OUT> {
     private Boundedness boundedness;
     private PulsarDeserializationSchema<OUT> deserializationSchema;
     private PulsarCrypto pulsarCrypto;
+
+    private SourceUserCallbackFactory<OUT> userCallbackFactory;
 
     // private builder constructor.
     PulsarSourceBuilder() {
@@ -537,6 +542,19 @@ public final class PulsarSourceBuilder<OUT> {
     }
 
     /**
+     * Set a factory for the {@link SourceUserCallback}. A callback is instantiated in each {@link
+     * SourceReader} and disposed of when the app shuts down.
+     *
+     * @param callbackFactory the factory.
+     * @return this PulsarSourceBuilder.
+     */
+    public PulsarSourceBuilder<OUT> setUserCallbackFactory(
+            SourceUserCallbackFactory<OUT> callbackFactory) {
+        this.userCallbackFactory = callbackFactory;
+        return this;
+    }
+
+    /**
      * Build the {@link PulsarSource}.
      *
      * @return a PulsarSource with the settings made for this builder.
@@ -612,7 +630,8 @@ public final class PulsarSourceBuilder<OUT> {
                 stopCursor,
                 boundedness,
                 deserializationSchema,
-                pulsarCrypto);
+                pulsarCrypto,
+                userCallbackFactory);
     }
 
     // ------------- private helpers  --------------

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallback.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallback.java
@@ -33,7 +33,6 @@ public interface SourceUserCallback<T> extends AutoCloseable {
      * <p>By default, this will return the unmodified message.
      *
      * @param rawMessage the raw message from the pulsar topic
-     * @return Either the same message or a modified message
      */
     void beforeCollect(Message<byte[]> rawMessage);
 

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallback.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallback.java
@@ -2,12 +2,18 @@ package org.apache.flink.connector.pulsar.source.callback;
 
 import org.apache.pulsar.client.api.Message;
 
+/**
+ * An optional interface that users can plug into PulsarSource.
+ *
+ * @param <T> The output type of Source
+ */
 public interface SourceUserCallback<T> extends AutoCloseable {
     /**
-     * This method is called before the message is passed forward to the Collector
-     * The user can modify the message here before it is passed along.
-     * <p />
-     * By default, this will return the unmodified message.
+     * This method is called before the message is passed forward to the Collector The user can
+     * modify the message here before it is passed along.
+     *
+     * <p>By default, this will return the unmodified message.
+     *
      * @param rawMessage the raw message from the pulsar topic
      * @return Either the same message or a modified message
      */
@@ -16,12 +22,11 @@ public interface SourceUserCallback<T> extends AutoCloseable {
     }
 
     /**
-     * This method is called after the message is handed off to the Collector,
-     * with the raw message from pulsar, as well as the deserialized value.
+     * This method is called after the message is handed off to the Collector, with the raw message
+     * from pulsar, as well as the deserialized value.
      *
-     * <p />
+     * <p>Modifications to the message will not carry forward.
      *
-     * Modifications to the message will not carry forward.
      * @param rawMessage the raw message from the pulsar topic
      * @param deserializedElement the deserialized message body
      */

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallback.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallback.java
@@ -35,9 +35,7 @@ public interface SourceUserCallback<T> extends AutoCloseable {
      * @param rawMessage the raw message from the pulsar topic
      * @return Either the same message or a modified message
      */
-    default Message<byte[]> beforeCollect(Message<byte[]> rawMessage) {
-        return rawMessage;
-    }
+    void beforeCollect(Message<byte[]> rawMessage);
 
     /**
      * This method is called after the message is handed off to the Collector, with the raw message

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallback.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallback.java
@@ -1,0 +1,29 @@
+package org.apache.flink.connector.pulsar.source.callback;
+
+import org.apache.pulsar.client.api.Message;
+
+public interface SourceUserCallback<T> extends AutoCloseable {
+    /**
+     * This method is called before the message is passed forward to the Collector
+     * The user can modify the message here before it is passed along.
+     * <p />
+     * By default, this will return the unmodified message.
+     * @param rawMessage the raw message from the pulsar topic
+     * @return Either the same message or a modified message
+     */
+    default Message<byte[]> beforeCollect(Message<byte[]> rawMessage) {
+        return rawMessage;
+    }
+
+    /**
+     * This method is called after the message is handed off to the Collector,
+     * with the raw message from pulsar, as well as the deserialized value.
+     *
+     * <p />
+     *
+     * Modifications to the message will not carry forward.
+     * @param rawMessage the raw message from the pulsar topic
+     * @param deserializedElement the deserialized message body
+     */
+    void afterCollect(Message<byte[]> rawMessage, T deserializedElement);
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallback.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallback.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.connector.pulsar.source.callback;
 
 import org.apache.pulsar.client.api.Message;

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallback.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallback.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.connector.pulsar.source.callback;
 
+import org.apache.flink.annotation.PublicEvolving;
+
 import org.apache.pulsar.client.api.Message;
 
 /**
@@ -25,6 +27,7 @@ import org.apache.pulsar.client.api.Message;
  *
  * @param <T> The output type of Source
  */
+@PublicEvolving
 public interface SourceUserCallback<T> extends AutoCloseable {
     /**
      * This method is called before the message is passed forward to the Collector The user can

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallbackFactory.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallbackFactory.java
@@ -2,6 +2,8 @@ package org.apache.flink.connector.pulsar.source.callback;
 
 import java.io.Serializable;
 
+ /** A serializable factory for SourceUserCallback.
+ * @param <T> the outupt type of the source*/
 public interface SourceUserCallbackFactory<T> extends Serializable {
     SourceUserCallback<T> create();
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallbackFactory.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallbackFactory.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.connector.pulsar.source.callback;
 
+import org.apache.flink.annotation.PublicEvolving;
+
 import java.io.Serializable;
 
 /**
@@ -25,6 +27,7 @@ import java.io.Serializable;
  *
  * @param <T> the outupt type of the source
  */
+@PublicEvolving
 public interface SourceUserCallbackFactory<T> extends Serializable {
     SourceUserCallback<T> create();
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallbackFactory.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallbackFactory.java
@@ -1,0 +1,5 @@
+package org.apache.flink.connector.pulsar.source.callback;
+
+public interface SourceUserCallbackFactory<T> {
+    SourceUserCallback<T> create();
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallbackFactory.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallbackFactory.java
@@ -1,5 +1,7 @@
 package org.apache.flink.connector.pulsar.source.callback;
 
-public interface SourceUserCallbackFactory<T> {
+import java.io.Serializable;
+
+public interface SourceUserCallbackFactory<T> extends Serializable {
     SourceUserCallback<T> create();
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallbackFactory.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/callback/SourceUserCallbackFactory.java
@@ -1,9 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.connector.pulsar.source.callback;
 
 import java.io.Serializable;
 
- /** A serializable factory for SourceUserCallback.
- * @param <T> the outupt type of the source*/
+/**
+ * A serializable factory for SourceUserCallback.
+ *
+ * @param <T> the outupt type of the source
+ */
 public interface SourceUserCallbackFactory<T> extends Serializable {
     SourceUserCallback<T> create();
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/PulsarRecordEmitter.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/PulsarRecordEmitter.java
@@ -53,11 +53,8 @@ public class PulsarRecordEmitter<T>
             Message<byte[]> element, SourceOutput<T> output, PulsarPartitionSplitState splitState)
             throws Exception {
         // pass the message to the user callback
-        Message<byte[]> userElement;
         if (userCallback != null) {
-            userElement = userCallback.beforeCollect(element);
-        } else {
-            userElement = element;
+            userCallback.beforeCollect(element);
         }
 
         // Update the source output.
@@ -72,12 +69,7 @@ public class PulsarRecordEmitter<T>
         }
 
         // Release the messages if we use message pool in Pulsar.
-        if (element == userElement) {
-            element.release();
-        } else {
-            userElement.release();
-            element.release();
-        }
+        element.release();
     }
 
     private static class SourceOutputWrapper<T> implements Collector<T> {

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/PulsarRecordEmitter.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/PulsarRecordEmitter.java
@@ -27,6 +27,8 @@ import org.apache.flink.util.Collector;
 
 import org.apache.pulsar.client.api.Message;
 
+import javax.annotation.Nullable;
+
 /**
  * The {@link RecordEmitter} implementation for {@link PulsarSourceReader}. We would always update
  * the last consumed message id in this emitter.
@@ -36,10 +38,13 @@ public class PulsarRecordEmitter<T>
 
     private final PulsarDeserializationSchema<T> deserializationSchema;
     private final SourceOutputWrapper<T> sourceOutputWrapper;
-    private SourceUserCallback<T> userCallback;
+    private final SourceUserCallback<T> userCallback;
 
-    public PulsarRecordEmitter(PulsarDeserializationSchema<T> deserializationSchema) {
+    public PulsarRecordEmitter(
+            PulsarDeserializationSchema<T> deserializationSchema,
+            @Nullable SourceUserCallback<T> userCallback) {
         this.deserializationSchema = deserializationSchema;
+        this.userCallback = userCallback;
         this.sourceOutputWrapper = new SourceOutputWrapper<>();
     }
 

--- a/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriterTest.java
+++ b/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriterTest.java
@@ -104,7 +104,7 @@ class PulsarWriterTest extends PulsarTestSuiteBase {
                         delayer,
                         PulsarCrypto.disabled(),
                         initContext,
-                    null);
+                        null);
 
         writer.flush(false);
         writer.prepareCommit();

--- a/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriterTest.java
+++ b/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriterTest.java
@@ -103,7 +103,8 @@ class PulsarWriterTest extends PulsarTestSuiteBase {
                         router,
                         delayer,
                         PulsarCrypto.disabled(),
-                        initContext);
+                        initContext,
+                    null);
 
         writer.flush(false);
         writer.prepareCommit();

--- a/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/PulsarSourceReaderTest.java
+++ b/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/PulsarSourceReaderTest.java
@@ -247,7 +247,7 @@ class PulsarSourceReaderTest extends PulsarTestSuiteBase {
         SourceConfiguration sourceConfiguration = new SourceConfiguration(configuration);
 
         return PulsarSourceReader.create(
-                sourceConfiguration, deserializationSchema, PulsarCrypto.disabled(), context);
+                sourceConfiguration, deserializationSchema, PulsarCrypto.disabled(), context, null);
     }
 
     private void setupSourceReader(


### PR DESCRIPTION
<!--
*Thank you for contributing to Apache Flink Pulsar Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][Component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number.
    Generally, [Component] tag should indicate the part you modified. The options are: [Stream | Table | Test | E2E | Build].
    For example: "[FLINK-XXXX][Stream] XXXX" if you are working on the `DataStream` part of pulsar connector or "[FLINK-XXXX][Test] XXXX" if this pull request is only used for adding tests.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change

 Support user callbacks in `PulsarSource` and `PulsarSink`. The specific use case we have is to enable event tracing which requires access to low level message properties such as message IDs after an event is produced, topic partitions, etc...

## Brief change log

- Introduce `SourceUserCallback` and `SinkUserCallback` interfaces.
- Update `PulsarSourceBuilder` and `PulsarSinkBuilder` to provide hook for factories of the user callbacks.
- Update `PulsarRecordEmitter` to call the `SourceUserCallback` if it exists.
- Update `PulsarWriter` to call the `SinkUserCallback` if it exists.

## Verifying this change

// this section is a todo

<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality
guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*

- *Added unit tests*
- *Added integration tests for end-to-end deployment*
- *Manually verified by running the Pulsar connector on a local Flink cluster.*

## Significant changes

*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for
convenience.)*

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
-->